### PR TITLE
Add Anthropic Claude 3 AI models to autocompletion

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"typescript": "4.7.4"
 	},
 	"dependencies": {
+		"@anthropic-ai/sdk": "^0.19.0",
 		"@types/mustache": "^4.2.2",
 		"@types/react": "^18.0.28",
 		"@types/react-dom": "^18.0.11",

--- a/src/complete/completers.ts
+++ b/src/complete/completers.ts
@@ -4,6 +4,7 @@ import { ChatGPTComplete } from "./completers/chatgpt/chatgpt";
 import { JurassicJ2Complete } from "./completers/ai21/ai21";
 import { GooseAIComplete } from "./completers/gooseai/gooseai";
 import { OobaboogaComplete } from "./completers/oobabooga/oobabooga";
+import { AnthropicComplete } from "./completers/anthropic/anthropic";
 
 export const available: Completer[] = [
 	new ChatGPTComplete(),
@@ -11,4 +12,5 @@ export const available: Completer[] = [
 	new JurassicJ2Complete(),
 	new GooseAIComplete(),
 	new OobaboogaComplete(),
+	new AnthropicComplete(),
 ];

--- a/src/complete/completers/anthropic/anthropic.tsx
+++ b/src/complete/completers/anthropic/anthropic.tsx
@@ -1,0 +1,208 @@
+import { Completer, Model, Prompt } from "../../complete";
+import { Notice } from "obsidian";
+import {
+	SettingsUI as ProviderSettingsUI,
+	Settings as ProviderSettings,
+	parse_settings as parse_provider_settings,
+} from "./provider_settings";
+import {
+	SettingsUI as ModelSettingsUI,
+	parse_settings as parse_model_settings,
+	Settings as ModelSettings,
+} from "./model_settings";
+import Anthropic from "@anthropic-ai/sdk";
+import Mustache from "mustache";
+import ContentBlockDeltaEvent = Anthropic.ContentBlockDeltaEvent;
+
+class AnthropicAI implements Model {
+	id: string;
+	name: string;
+	description: string;
+	rate_limit_notice: Notice | null = null;
+	rate_limit_notice_timeout: number | null = null;
+	Settings  = ModelSettingsUI;
+
+	provider_settings: ProviderSettings;
+
+	constructor(
+		provider_settings: string,
+		id: string,
+		name: string,
+		description: string
+	) {
+		this.id = id;
+		this.name = name;
+		this.description = description;
+		this.provider_settings = parse_provider_settings(provider_settings);
+	}
+
+
+	async prepare(prompt: Prompt, settings: ModelSettings): Promise<Prompt> {
+		// See the ChatGPT version of this for details
+		// TODO: make this work properly, with context from other notes
+
+		return {
+			prefix: prompt.prefix.slice(-(settings.prompt_length || 4096)),
+			suffix: prompt.suffix.slice(0, settings.prompt_length || 4096),
+		};
+	}
+
+
+	async generate_messages(
+		prompt: Prompt,
+		model_settings: {
+			system_prompt: string;
+			user_prompt: string;
+		}
+	): Promise<{ role: "assistant" | "user"; content: string }[]> {
+		return [
+			{
+				role: "assistant",
+				content: model_settings.system_prompt,
+			},
+			{
+				role: "user",
+				content: Mustache.render(model_settings.user_prompt, prompt),
+			},
+		];
+	}
+
+	model_parameters(model_settings: ModelSettings): {
+		top_p: number | undefined;
+		top_k: any;
+		temperature: number | undefined
+	} {
+		return {
+			temperature: model_settings.temperature,
+			top_p: model_settings.top_p,
+			top_k: model_settings.top_k,
+		}
+	}
+
+
+	create_rate_limit_notice() {
+		if (this.rate_limit_notice) {
+			window.clearTimeout(this.rate_limit_notice_timeout!);
+			this.rate_limit_notice_timeout = window.setTimeout(() => {
+				this.rate_limit_notice?.hide();
+				this.rate_limit_notice = null;
+				this.rate_limit_notice_timeout = null;
+			}, 5000);
+		} else {
+			this.rate_limit_notice = new Notice(
+				"Rate limit exceeded. Please wait a few minutes and try again."
+			);
+			this.rate_limit_notice_timeout = window.setTimeout(() => {
+				this.rate_limit_notice?.hide();
+				this.rate_limit_notice = null;
+				this.rate_limit_notice_timeout = null;
+			}, 5000);
+		}
+	}
+
+	create_api_key_notice() {
+		const notice: any = new Notice("", 5000);
+		 const notice_element = notice.noticeEl as HTMLElement;
+		notice_element.createEl("span", {
+			text: "Anthropic API key is invalid. Please double-check your ",
+		});
+		notice_element.createEl("a", {
+			text: "API key",
+			href: "https://console.anthropic.com/settings/keys",
+		});
+		notice_element.createEl("span", {
+			text: " in the plugin settings.",
+		});
+	}
+
+	parse_api_error(e: { status?: number }) {
+		if (e.status === 429) {
+			this.create_rate_limit_notice();
+			throw new Error();
+		} else if (e.status === 401) {
+			this.create_api_key_notice();
+			throw new Error();
+		}
+		throw e;
+	}
+
+	get_api() {
+		return new Anthropic({
+			apiKey: this.provider_settings.api_key,
+		});
+	}
+
+	async complete(prompt: Prompt, settings: string): Promise<string> {
+		const model_settings = parse_model_settings(settings);
+		const api = this.get_api();
+
+		try {
+			const response = await api.messages.create({
+				...this.model_parameters(model_settings),
+				messages: await this.generate_messages(prompt, model_settings),
+				model: this.id,
+				max_tokens: 64,
+			});
+
+			return response.content[0].text;
+		} catch (e) {
+			this.parse_api_error(e);
+			throw e;
+		}
+	}
+
+	async *iterate(prompt: Prompt, settings: string): AsyncGenerator<string> {
+		const model_settings = parse_model_settings(settings);
+		const api = this.get_api();
+
+		try {
+			const stream = await api.messages.create({
+				...this.model_parameters(model_settings),
+				messages: await this.generate_messages(prompt, model_settings),
+				model: this.id,
+				max_tokens: 64,
+				stream: true,
+			});
+
+			for await (const response of stream) {
+				if (response.type === "content_block_delta") {
+					yield response.delta.text;
+				}
+			}
+		} catch (e) {
+			this.parse_api_error(e);
+			throw e;
+		}
+	}
+}
+
+export class AnthropicComplete implements Completer {
+	id: string = "anthropic";
+	name: string = "Anthropic AI";
+	description: string = "Anthropic's AI language model";
+
+	async get_models(settings: string) {
+		return [
+			new AnthropicAI(
+				settings,
+				"claude-3-haiku-20240307",
+				"Claude 3 Haiku (recommended)",
+				"Fastest and most cost-effective model for Claude 3"
+			),
+			new AnthropicAI(
+				settings,
+				"claude-3-sonnet-20240229",
+				"Claude 3 Sonnet",
+				"Balanced speed and intelligence model for Claude 3"
+			),
+			new AnthropicAI(
+				settings,
+				"claude-3-opus-20240229",
+				"Claude 3 Opus",
+				"Most intelligent model for Claude 3"
+			)
+		];
+	}
+
+	Settings = ProviderSettingsUI;
+}

--- a/src/complete/completers/anthropic/anthropic.tsx
+++ b/src/complete/completers/anthropic/anthropic.tsx
@@ -12,7 +12,6 @@ import {
 } from "./model_settings";
 import Anthropic from "@anthropic-ai/sdk";
 import Mustache from "mustache";
-import ContentBlockDeltaEvent = Anthropic.ContentBlockDeltaEvent;
 
 class AnthropicAI implements Model {
 	id: string;
@@ -51,15 +50,10 @@ class AnthropicAI implements Model {
 	async generate_messages(
 		prompt: Prompt,
 		model_settings: {
-			system_prompt: string;
 			user_prompt: string;
 		}
 	): Promise<{ role: "assistant" | "user"; content: string }[]> {
 		return [
-			{
-				role: "assistant",
-				content: model_settings.system_prompt,
-			},
 			{
 				role: "user",
 				content: Mustache.render(model_settings.user_prompt, prompt),
@@ -129,6 +123,7 @@ class AnthropicAI implements Model {
 	get_api() {
 		return new Anthropic({
 			apiKey: this.provider_settings.api_key,
+			baseURL: this.provider_settings.host_url,
 		});
 	}
 
@@ -142,6 +137,7 @@ class AnthropicAI implements Model {
 				messages: await this.generate_messages(prompt, model_settings),
 				model: this.id,
 				max_tokens: 64,
+				system: model_settings.system_prompt,
 			});
 
 			return response.content[0].text;
@@ -159,6 +155,7 @@ class AnthropicAI implements Model {
 			const stream = await api.messages.create({
 				...this.model_parameters(model_settings),
 				messages: await this.generate_messages(prompt, model_settings),
+				system: model_settings.system_prompt,
 				model: this.id,
 				max_tokens: 64,
 				stream: true,

--- a/src/complete/completers/anthropic/model_settings.tsx
+++ b/src/complete/completers/anthropic/model_settings.tsx
@@ -1,15 +1,14 @@
-import * as React from "react";
-import SettingsItem from "../../../components/SettingsItem";
+import React from "react";
 import { z } from "zod";
+import SettingsItem from "../../../components/SettingsItem";
 
 export const settings_schema = z.object({
 	system_prompt: z.string(),
 	user_prompt: z.string(),
+	prompt_length: z.number().optional(),
 	temperature: z.number().optional(),
 	top_p: z.number().optional(),
-	presence_penalty: z.number().optional(),
-	frequency_penalty: z.number().optional(),
-	prompt_length: z.number().optional(),
+	top_k: z.number().optional(),
 });
 
 export type Settings = z.infer<typeof settings_schema>;
@@ -18,6 +17,7 @@ const default_settings: Settings = {
 	system_prompt:
 		"You are trying to give a long suggestion on how to complete the user's message. Complete in the language of the original message. Write only the completion and nothing else. Do not include the user's text in your message. Only include the completion.",
 	user_prompt: "Continue the following:\n\n{{prefix}}",
+	prompt_length: 256,
 };
 
 export const parse_settings = (data: string | null): Settings => {
@@ -30,7 +30,7 @@ export const parse_settings = (data: string | null): Settings => {
 	} catch (e) {
 		return default_settings;
 	}
-};
+}
 
 export function SettingsUI({
 	settings,
@@ -80,14 +80,24 @@ export function SettingsUI({
 					)
 				}
 			/>
+			<SettingsItem name="Max tokens">
+				<input
+					type="number"
+					value={parsed_settings.prompt_length}
+					onChange={(e) =>
+						saveSettings(
+							JSON.stringify({
+								...parsed_settings,
+								prompt_length: parseInt(e.target.value),
+							})
+						)
+					}
+				/>
+			</SettingsItem>
 			<SettingsItem name="Temperature">
 				<input
 					type="number"
-					value={
-						parsed_settings.temperature === undefined
-							? ""
-							: parsed_settings.temperature
-					}
+					value={parsed_settings.temperature}
 					onChange={(e) =>
 						saveSettings(
 							JSON.stringify({
@@ -101,11 +111,7 @@ export function SettingsUI({
 			<SettingsItem name="Top P">
 				<input
 					type="number"
-					value={
-						parsed_settings.top_p === undefined
-							? ""
-							: parsed_settings.top_p
-					}
+					value={parsed_settings.top_p}
 					onChange={(e) =>
 						saveSettings(
 							JSON.stringify({
@@ -116,63 +122,15 @@ export function SettingsUI({
 					}
 				/>
 			</SettingsItem>
-			<SettingsItem name="Presence penalty">
+			<SettingsItem name="Top K">
 				<input
 					type="number"
-					value={
-						parsed_settings.presence_penalty === undefined
-							? ""
-							: parsed_settings.presence_penalty
-					}
+					value={parsed_settings.top_k}
 					onChange={(e) =>
 						saveSettings(
 							JSON.stringify({
 								...parsed_settings,
-								presence_penalty: parseFloat(e.target.value),
-							})
-						)
-					}
-				/>
-			</SettingsItem>
-			<SettingsItem name="Frequency penalty">
-				<input
-					type="number"
-					value={
-						parsed_settings.frequency_penalty === undefined
-							? ""
-							: parsed_settings.frequency_penalty
-					}
-					onChange={(e) =>
-						saveSettings(
-							JSON.stringify({
-								...parsed_settings,
-								frequency_penalty: parseFloat(e.target.value),
-							})
-						)
-					}
-				/>
-			</SettingsItem>
-			<SettingsItem
-				name="Prompt length"
-				description={
-					<>
-						The length of both the prefix and the suffix of the
-						prompt, in characters.
-					</>
-				}
-			>
-				<input
-					type="number"
-					value={
-						parsed_settings.prompt_length === undefined
-							? ""
-							: parsed_settings.prompt_length
-					}
-					onChange={(e) =>
-						saveSettings(
-							JSON.stringify({
-								...parsed_settings,
-								prompt_length: parseInt(e.target.value),
+								top_K: parseFloat(e.target.value),
 							})
 						)
 					}

--- a/src/complete/completers/anthropic/provider_settings.tsx
+++ b/src/complete/completers/anthropic/provider_settings.tsx
@@ -4,12 +4,14 @@ import SettingsItem from "../../../components/SettingsItem";
 
 export const settings_schema = z.object({
 	api_key: z.string(),
+	host_url: z.string().optional(),
 });
 
 export type Settings = z.infer<typeof settings_schema>;
 
 const default_settings: Settings = {
 	api_key: "",
+	host_url: "https://api.anthropic.com",
 };
 
 export const parse_settings = (data: string | null): Settings => {
@@ -31,25 +33,55 @@ export function SettingsUI({
 	settings: string | null;
 	saveSettings: (settings: string) => void;
 }) {
+	const parsed_settings = parse_settings(settings);
+
 	return (
-		<SettingsItem
-			name="API key"
-			description={
-				<>
-					Your Anthropic{" "}
-					<a href="https://console.anthropic.com/settings/keys">
-						API key
-					</a>
-				</>
-			}
-		>
-			<input
-				type="text"
-				value={parse_settings(settings).api_key}
-				onChange={(e) =>
-					saveSettings(JSON.stringify({ api_key: e.target.value }))
+		<>
+			<SettingsItem
+				name="API URL"
+				description={
+					<>
+						Your{" "}
+						<a href="https://console.anthropic.com/settings/keys">
+							Anthropic
+						</a>{" "}
+						API host URL. Due to CORS, you will need to relay all requests to the Anthropic API.
+					</>
 				}
-			/>
-		</SettingsItem>
+			>
+				<input
+					type="text"
+					value={parsed_settings.host_url}
+					onChange={(e) =>
+						saveSettings(JSON.stringify({ 
+							...parsed_settings,
+							host_url: e.target.value 
+						}))
+					}
+				/>
+			</SettingsItem>
+			<SettingsItem
+				name="API key"
+				description={
+					<>
+						Your Anthropic{" "}
+						<a href="https://console.anthropic.com/settings/keys">
+							API key
+						</a>
+					</>
+				}
+			>
+				<input
+					type="text"
+					value={parsed_settings.api_key}
+					onChange={(e) =>
+						saveSettings(JSON.stringify({ 
+							...parsed_settings,
+							api_key: e.target.value,
+						}))
+					}
+				/>
+			</SettingsItem>
+		</>
 	);
 }

--- a/src/complete/completers/anthropic/provider_settings.tsx
+++ b/src/complete/completers/anthropic/provider_settings.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { z } from "zod";
+import SettingsItem from "../../../components/SettingsItem";
+
+export const settings_schema = z.object({
+	api_key: z.string(),
+});
+
+export type Settings = z.infer<typeof settings_schema>;
+
+const default_settings: Settings = {
+	api_key: "",
+};
+
+export const parse_settings = (data: string | null): Settings => {
+	if (data === null) {
+		return default_settings;
+	}
+	try {
+		const settings: unknown = JSON.parse(data);
+		return settings_schema.parse(settings);
+	} catch (e) {
+		return default_settings;
+	}
+};
+
+export function SettingsUI({
+	settings,
+	saveSettings,
+}: {
+	settings: string | null;
+	saveSettings: (settings: string) => void;
+}) {
+	return (
+		<SettingsItem
+			name="API key"
+			description={
+				<>
+					Your Anthropic{" "}
+					<a href="https://console.anthropic.com/settings/keys">
+						API key
+					</a>
+				</>
+			}
+		>
+			<input
+				type="text"
+				value={parse_settings(settings).api_key}
+				onChange={(e) =>
+					saveSettings(JSON.stringify({ api_key: e.target.value }))
+				}
+			/>
+		</SettingsItem>
+	);
+}

--- a/src/complete/completers/chatgpt/chatgpt.sass
+++ b/src/complete/completers/chatgpt/chatgpt.sass
@@ -1,4 +1,4 @@
-.ai-complete-chatgpt-full-width
+.ai-complete-full-width
     width: 100%
     min-height: 120px
     resize: none

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,21 @@
 # yarn lockfile v1
 
 
+"@anthropic-ai/sdk@^0.19.0":
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/@anthropic-ai/sdk/-/sdk-0.19.0.tgz#a0dc20998b383ef3406be723d92940fecd1aee3f"
+  integrity sha512-mv4JtBGLKtpi7XK6Car2Tb+xwdgOuaMtRxxJoO27tqFESgGWdlxSWU65ntjIXAFFLABbRCtVFsnXTBS1AlF6NQ==
+  dependencies:
+    "@types/node" "^18.11.18"
+    "@types/node-fetch" "^2.6.4"
+    abort-controller "^3.0.0"
+    agentkeepalive "^4.2.1"
+    digest-fetch "^1.3.0"
+    form-data-encoder "1.7.2"
+    formdata-node "^4.3.2"
+    node-fetch "^2.6.7"
+    web-streams-polyfill "^3.2.1"
+
 "@codemirror/autocomplete@^6.0.0":
   version "6.6.0"
   resolved "https://registry.yarnpkg.com/@codemirror/autocomplete/-/autocomplete-6.6.0.tgz#9c0ea57792b405a391599bd80acae19b8c4c6ff5"


### PR DESCRIPTION
This pull request adds the [Claude 3](https://www.anthropic.com/news/claude-3-family) family of AI models, by Anthropic, to the possible models supported by this plugin. Usage of the models requires an API key that you can acquire by making an account on the [Anthropic console](https://console.anthropic.com/). In addition, you will need some sort of relay server or CORS proxy to handle sending the actual requests to Anthropic; CORS errors will prevent you from using the API endpoints directly.

Claude 3 Haiku, Sonnet, and Opus are supported. Please mind the [rate limits](https://docs.anthropic.com/claude/reference/rate-limits).

**Changes involved:**

- Add the Anthropic SDK to packages
- Add an Anthropic completer, provider settings, and model settings